### PR TITLE
no oob callback in request

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@ function myFunction() {
             $("#login").click(function(){
                 cb.__call(
                 "oauth_requestToken",
-                {oauth_callback: "oob"},
                 function (reply) {
                     // stores it
                     cb.setToken(reply.oauth_token, reply.oauth_token_secret);


### PR DESCRIPTION
this gets rid of the pin and directly sends the user to the website
after “authentication”
